### PR TITLE
HOCS-5579: add ability to read queue attributes 

### DIFF
--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/controller/QueueAdminController.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/controller/QueueAdminController.kt
@@ -32,4 +32,10 @@ class QueueAdminController(private val queueAdminService: QueueAdminService) {
     return ResponseEntity.ok(queueAdminService.sendMessage(pair, message));
   }
 
+  @GetMapping("/attributes")
+  fun printAttributesOfQueue(@RequestParam(name = "queue") pair : QueuePairName,
+                             @RequestParam(name = "dlq", defaultValue = false.toString()) dlq : Boolean) : ResponseEntity<Map<String, String>> {
+    return ResponseEntity.ok(queueAdminService.printAttributes(pair, dlq));
+  }
+
 }

--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/service/QueueAdminService.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/service/QueueAdminService.kt
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.queue.service
 import com.amazonaws.services.sqs.AmazonSQS
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.DeleteMessageRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
 import com.amazonaws.services.sqs.model.PurgeQueueRequest
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.google.gson.Gson
@@ -69,6 +70,19 @@ class QueueAdminService(
     fun sendMessage(name: QueuePairName, message: String) : String {
         with (queueHelper.getQueuePair(name)) {
             return mainClient.sendMessage(mainEndpoint, message).messageId
+        }
+    }
+
+    fun printAttributes(name: QueuePairName, dlq: Boolean) : Map<String, String> {
+        with (queueHelper.getQueuePair(name)) {
+            if (dlq) {
+                if (dlqClient == null || dlqEndpoint == null) {
+                    throw IllegalArgumentException("No DLQ setup for queue $name")
+                }
+                return dlqClient.getQueueAttributes(GetQueueAttributesRequest(dlqEndpoint, listOf("All"))).attributes
+            } else {
+                return mainClient.getQueueAttributes(GetQueueAttributesRequest(mainEndpoint, listOf("All"))).attributes
+            }
         }
     }
 

--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/service/QueueAdminService.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/service/QueueAdminService.kt
@@ -73,7 +73,7 @@ class QueueAdminService(
     }
 
     private fun getMessageCount(amazonSQS: AmazonSQS, dlqUrl : String) =
-        amazonSQS.getQueueAttributes(dlqUrl,listOf("ApproximateNumberOfMessages")).attributes["ApproximateNumberOfMessages"]?.toInt() ?: 0
+        amazonSQS.getQueueAttributes(dlqUrl, listOf("ApproximateNumberOfMessages")).attributes["ApproximateNumberOfMessages"]?.toInt() ?: 0
 
     private fun AmazonSQSAsync.receiveOneMessage(dlqEndpoint : String) =
         this.receiveMessage(ReceiveMessageRequest(dlqEndpoint).withMaxNumberOfMessages(1)).messages.firstOrNull()

--- a/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/AttributesQueueTest.kt
+++ b/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/AttributesQueueTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.digital.ho.hocs.queue.service
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.digital.ho.hocs.queue.domain.QueuePair
+import uk.gov.digital.ho.hocs.queue.domain.enum.QueuePairName
+
+class AttributesQueueTest : BaseQueueHelper() {
+
+  @ParameterizedTest
+  @MethodSource("getQueuePairs")
+  fun `view attributes of main queues`(queuePair : QueuePair, queuePairName : QueuePairName) {
+    with (queuePair) {
+      putMessageOnQueue(mainClient, mainEndpoint, 2)
+
+      val response = webTestClient.get().uri("/attributes?queue=$queuePairName")
+        .exchange();
+
+      response.expectStatus().isOk;
+
+      Assertions.assertTrue(
+        response
+          .returnResult<Map<String, String>>()
+          .responseBody
+          .blockFirst()?.getOrDefault(MESSAGE_COUNT_ATTRIBUTE, "-1") == "2"
+      )
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("getQueuePairs")
+  fun `view attributes of dlq`(queuePair : QueuePair, queuePairName : QueuePairName) {
+    with (queuePair) {
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!, 2)
+
+      val response = webTestClient.get().uri("/attributes?queue=$queuePairName&dlq=true")
+        .exchange();
+
+      response.expectStatus().isOk;
+
+      Assertions.assertTrue(
+        response
+          .returnResult<Map<String, String>>()
+          .responseBody
+          .blockFirst()?.getOrDefault(MESSAGE_COUNT_ATTRIBUTE, "-1") == "2"
+      )
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["","?","?queue=","?queue=search","?queue=SAUSAGES"])
+  fun `throws an exception if no valid queue pair is referenced`(queryString : String){
+    webTestClient.get().uri("/attributes$queryString")
+      .exchange()
+      .expectStatus()
+      .is4xxClientError
+  }
+
+  @Test
+  fun `throws exception with non-boolean dlq value`() {
+    webTestClient.get().uri("/attributes?queue=${QueuePairName.MIGRATION}&dlq=test")
+      .exchange()
+      .expectStatus()
+      .is4xxClientError
+  }
+
+  @Test
+  fun `throws exception for queue without DLQ`() {
+    webTestClient.get().uri("/attributes?queue=${QueuePairName.MIGRATION}&dlq=true")
+      .exchange()
+      .expectStatus()
+      .is5xxServerError
+  }
+
+}

--- a/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/PrintQueueTest.kt
+++ b/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/PrintQueueTest.kt
@@ -13,12 +13,12 @@ class PrintQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `view 0 message from DLQ`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!, 0)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!, 0)
       webTestClient.get().uri("/printdlq?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
     }
   }
 
@@ -26,12 +26,12 @@ class PrintQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `view 1 message from DLQ`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,1)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,1)
       webTestClient.get().uri("/printdlq?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 1 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 1 }
     }
   }
 
@@ -39,12 +39,12 @@ class PrintQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `view 2 messages from DLQ`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,2)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,2)
       webTestClient.get().uri("/printdlq?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 2 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 2 }
     }
   }
 

--- a/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/PurgeQueueTest.kt
+++ b/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/PurgeQueueTest.kt
@@ -16,12 +16,12 @@ class PurgeQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `purge 0 message from DLQ`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,0)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,0)
       webTestClient.get().uri("/purgedlq?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
     }
   }
 
@@ -29,12 +29,12 @@ class PurgeQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `purge 1 message from DLQ`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,1)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,1)
       webTestClient.get().uri("/purgedlq?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
     }
   }
 
@@ -42,12 +42,12 @@ class PurgeQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `purge 2 messages from DLQ to main queue`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,2)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,2)
       webTestClient.get().uri("/purgedlq?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
     }
   }
 

--- a/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/SendQueueTest.kt
+++ b/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/SendQueueTest.kt
@@ -24,7 +24,7 @@ class SendQueueTest : BaseQueueHelper() {
         .expectStatus()
         .isOk
 
-      await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(mainClient, mainEndpoint) } matches { it == 1 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(mainClient, mainEndpoint) } matches { it == 1 }
     }
   }
 

--- a/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/TransferQueueTest.kt
+++ b/src/test/kotlin/uk/gov/digital/ho/hocs/queue/service/TransferQueueTest.kt
@@ -16,13 +16,13 @@ class TransferQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `moves 0 message from DLQ to main queue`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,0)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,0)
       webTestClient.get().uri("/transfer?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
-      await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(mainClient, mainEndpoint) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(mainClient, mainEndpoint) } matches { it == 0 }
     }
   }
 
@@ -30,13 +30,13 @@ class TransferQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `moves 1 message from DLQ to main queue`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,1)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,1)
       webTestClient.get().uri("/transfer?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
-      await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(mainClient, mainEndpoint) } matches { it == 1 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(mainClient, mainEndpoint) } matches { it == 1 }
     }
   }
 
@@ -44,13 +44,13 @@ class TransferQueueTest : BaseQueueHelper() {
   @MethodSource("getQueuePairs")
   fun `moves 2 messages from DLQ to main queue`(queuePair : QueuePair, queuePairName : QueuePairName) {
     with (queuePair) {
-      putMessageOnDlq(dlqClient!!, dlqEndpoint!!,2)
+      putMessageOnQueue(dlqClient!!, dlqEndpoint!!,2)
       webTestClient.get().uri("/transfer?queue=$queuePairName")
         .exchange()
         .expectStatus()
         .isOk
-      await untilCallTo { getNumberOfMessagesCurrentlyOnDeadLetterQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
-      await untilCallTo { getNumberOfMessagesCurrentlyOnEventQueue(mainClient, mainEndpoint) } matches { it == 2 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(dlqClient!!, dlqEndpoint!!) } matches { it == 0 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue(mainClient, mainEndpoint) } matches { it == 2 }
     }
   }
 


### PR DESCRIPTION
New REST endpoint and service method for retrieving the attributes of a
specified queue. If a queue doesn't have an associated DLQ then an
exception is thrown.

Rework the BaseQueueHelper to become more generic to expose to the user
that both DLQ and normal queues can be handled.