### PR TITLE
Allow deployment to envs without migration queue

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -7,6 +7,7 @@ export VERSION=${VERSION}
 QUEUES="audit,case-creator,document,notify,search,extracts"
 if [[ ${KUBE_NAMESPACE} == cs-dev ]]; then
   QUEUES+=",case-migrator"
+  export MIGRATION_QUEUE_ENABLED='true'
 fi
 export QUEUES=${QUEUES}
 
@@ -20,5 +21,5 @@ export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffic
 
 cd kd
 
-kd --timeout 10m \
+kd --timeout 10m --allow-missing=true \
     -f deployment.yaml \

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -21,5 +21,6 @@ export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffic
 
 cd kd
 
-kd --timeout 10m --allow-missing=true \
+kd --timeout 10m \
+    --allow-missing=true \
     -f deployment.yaml \

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -38,40 +38,42 @@ spec:
               value: 'aws'
 
             {{ range split .QUEUES "," }}
-            - name: {{upper .}}_QUEUE
+            - name: {{upper . | replace "-" "_"}}_QUEUE
               valueFrom:
                 secretKeyRef:
                   name: {{$.KUBE_NAMESPACE}}-{{lower .}}-sqs
                   key: sqs_queue_url
-            - name: {{upper .}}_QUEUE_ACCESS_KEY_ID
+            - name: {{upper . | replace "-" "_"}}_QUEUE_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{$.KUBE_NAMESPACE}}-{{lower .}}-sqs
                   key: access_key_id
-            - name: {{upper .}}_QUEUE_SECRET_ACCESS_KEY
+            - name: {{upper . | replace "-" "_"}}_QUEUE_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{$.KUBE_NAMESPACE}}-{{lower .}}-sqs
                   key: secret_access_key
-            - name: {{upper .}}_DLQ_QUEUE
+            - name: {{upper . | replace "-" "_"}}_DLQ_QUEUE
               valueFrom:
                 secretKeyRef:
                   name: {{$.KUBE_NAMESPACE}}-{{lower .}}-sqs
                   key: sqs_dlq_url
                   optional: true
-            - name: {{upper .}}_DLQ_ACCESS_KEY_ID
+            - name: {{upper . | replace "-" "_"}}_DLQ_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{$.KUBE_NAMESPACE}}-{{lower .}}-sqs
                   key: access_key_id
                   optional: true
-            - name: {{upper .}}_DLQ_SECRET_ACCESS_KEY
+            - name: {{upper . | replace "-" "_"}}_DLQ_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{$.KUBE_NAMESPACE}}-{{lower .}}-sqs
                   key: secret_access_key
                   optional: true
             {{end}}
+            - name: MIGRATION_QUEUE_ENABLED
+              value: {{.MIGRATION_QUEUE_ENABLED}}
 
           resources:
             limits:

--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/config/AwsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/config/AwsConfiguration.kt
@@ -129,7 +129,7 @@ class AwsConfiguration(
   }
 
   @Bean(name = ["migrationAwsSqsClient"])
-  @ConditionalOnProperty(prefix = "migration-queue", name = ["sqs-queue"])
+  @ConditionalOnProperty(prefix = "migration-queue", name = ["enabled"], havingValue = true.toString())
   fun migrationAwsSqsClient(): AmazonSQSAsync {
     val credentials: AWSCredentials = BasicAWSCredentials(migrationAccessKeyId, migrationSecretKey)
     return AmazonSQSAsyncClientBuilder

--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/config/AwsLocalStackConfiguration.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/config/AwsLocalStackConfiguration.kt
@@ -109,7 +109,7 @@ class AwsLocalStackConfiguration(
   }
 
   @Bean(name = ["migrationAwsSqsClient"])
-  @ConditionalOnProperty(prefix = "migration-queue", name = ["endpoint"])
+  @ConditionalOnProperty(prefix = "migration-queue", name = ["enabled"], havingValue = true.toString(), matchIfMissing = true)
   fun migrationAwsSqsClient(): AmazonSQSAsync {
     return AmazonSQSAsyncClientBuilder.standard()
       .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(migrationEndpoint, region))

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -42,16 +42,17 @@ notify-dlq:
   secret-access-key: ${notify.dlq.secret.access.key}
 
 case-creator-queue:
-  sqs-queue: ${case-creator.queue}
-  access-key-id: ${case-creator.queue.access.key.id}
-  secret-access-key: ${case-creator.queue.secret.access.key}
+  sqs-queue: ${case.creator.queue}
+  access-key-id: ${case.creator.queue.access.key.id}
+  secret-access-key: ${case.creator.queue.secret.access.key}
 
 case-creator-dlq:
-  sqs-queue: ${case-creator.dlq.queue}
-  access-key-id: ${case-creator.dlq.access.key.id}
-  secret-access-key: ${case-creator.dlq.secret.access.key}
+  sqs-queue: ${case.creator.dlq.queue}
+  access-key-id: ${case.creator.dlq.access.key.id}
+  secret-access-key: ${case.creator.dlq.secret.access.key}
 
 migration-queue:
-  sqs-queue: ${migration.queue}
-  access-key-id: ${migration.queue.access.key.id}
-  secret-access-key: ${migration.queue.secret.access.key}
+  enabled: ${migration.queue.enabled:false}
+  sqs-queue: ${migration.queue:UNSET}
+  access-key-id: ${migration.queue.access.key.id:UNSET}
+  secret-access-key: ${migration.queue.secret.access.key:UNSET}

--- a/src/test/kotlin/uk/gov/digital/ho/hocs/queue/config/helpers/QueueHelperTest.kt
+++ b/src/test/kotlin/uk/gov/digital/ho/hocs/queue/config/helpers/QueueHelperTest.kt
@@ -29,11 +29,6 @@ class QueueHelperTest {
         assertDoesNotThrow { queueHelper.getQueuePair(queuePair) }
     }
 
-    @Test
-    fun `get migration queue pair throws without property definition`() {
-        assertThrows<IllegalArgumentException> { queueHelper.getQueuePair(QueuePairName.MIGRATION) }
-    }
-
     fun getQueuePairNames() : Stream<Arguments> {
         return Stream.of(
             Arguments.of(QueuePairName.SEARCH),


### PR DESCRIPTION
Deploying the service to environments that don't currently have a migration queue is failing because of a failure to parse missing environment variables.

This change adds an enabled flag for the migration queue for bean generation, which defaults to enabled in an local environment. Default values of empty and false (for enabled) are passed when deploying to environments without a queue.

An additional flag is specified to `kd` to not fail on missing variables, resulting in no values being passed.