### PR TITLE
HOCS-6015: rework purge endpoint for both queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ curl http://localhost:10443/transfer?queue=AUDIT
 
 ### Purge
 
-`GET /purgedlq?queue=<<QUEUE>>`
+`GET /purge?queue=<<QUEUE>>&dlq=<<BOOL>>`
 
-Deletes all messages on the dead letter queue. To be used when the message can never be processed successfully.
+Deletes all messages from the specified queue.
 
 ```sh
-curl http://localhost:10443/purgedlq?queue=AUDIT
+curl http://localhost:10443/purge?queue=AUDIT&dlq=true 
 ```
 
 ### Print

--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/controller/QueueAdminController.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/controller/QueueAdminController.kt
@@ -6,36 +6,47 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.digital.ho.hocs.queue.service.QueueAdminService
 import uk.gov.digital.ho.hocs.queue.domain.enum.QueuePairName
+import uk.gov.digital.ho.hocs.queue.service.QueueAdminService
 
 @RestController
 class QueueAdminController(private val queueAdminService: QueueAdminService) {
 
-  @GetMapping("/transfer")
-  fun transferMessagesFromDeadLetterQueue(@RequestParam(name = "queue") pair : QueuePairName) {
-    queueAdminService.transferMessages(pair)
-  }
+    @GetMapping("/transfer")
+    fun transferMessagesFromDeadLetterQueue(@RequestParam(name = "queue") pair: QueuePairName) {
+        queueAdminService.transferMessages(pair)
+    }
 
-  @GetMapping("/purgedlq")
-  fun purgeMessagesFromDeadLetterQueue(@RequestParam(name = "queue") pair : QueuePairName) {
-    queueAdminService.purgeMessages(pair)
-  }
+    @GetMapping("/purge")
+    fun purgeMessagesFromQueue(
+        @RequestParam(name = "queue") pair: QueuePairName,
+        @RequestParam(name = "dlq") dlq: Boolean
+    ) {
+        queueAdminService.purgeMessages(pair, dlq)
+    }
 
-  @GetMapping("/printdlq")
-  fun printMessagesFromDeadLetterQueue(@RequestParam(name = "queue") pair : QueuePairName, @RequestParam(name = "count") num: Int?) : ResponseEntity<List<String>> {
-    return ResponseEntity.ok(queueAdminService.printMessages(pair, num))
-  }
+    @GetMapping("/printdlq")
+    fun printMessagesFromDeadLetterQueue(
+        @RequestParam(name = "queue") pair: QueuePairName,
+        @RequestParam(name = "count") num: Int?
+    ): ResponseEntity<List<String>> {
+        return ResponseEntity.ok(queueAdminService.printMessages(pair, num))
+    }
 
-  @PostMapping("/send")
-  fun sendMessageToMainQueue(@RequestParam(name = "queue") pair : QueuePairName, @RequestBody message: String) : ResponseEntity<String> {
-    return ResponseEntity.ok(queueAdminService.sendMessage(pair, message));
-  }
+    @PostMapping("/send")
+    fun sendMessageToMainQueue(
+        @RequestParam(name = "queue") pair: QueuePairName,
+        @RequestBody message: String
+    ): ResponseEntity<String> {
+        return ResponseEntity.ok(queueAdminService.sendMessage(pair, message));
+    }
 
-  @GetMapping("/attributes")
-  fun printAttributesOfQueue(@RequestParam(name = "queue") pair : QueuePairName,
-                             @RequestParam(name = "dlq", defaultValue = false.toString()) dlq : Boolean) : ResponseEntity<Map<String, String>> {
-    return ResponseEntity.ok(queueAdminService.printAttributes(pair, dlq));
-  }
+    @GetMapping("/attributes")
+    fun printAttributesOfQueue(
+        @RequestParam(name = "queue") pair: QueuePairName,
+        @RequestParam(name = "dlq", defaultValue = false.toString()) dlq: Boolean
+    ): ResponseEntity<Map<String, String>> {
+        return ResponseEntity.ok(queueAdminService.printAttributes(pair, dlq));
+    }
 
 }


### PR DESCRIPTION
Change the endpoint provided by the tool to support the purging of messages from the main queue and DLQ.