### PR TITLE
HOCS-6191: remove logging line

### DIFF
--- a/src/main/kotlin/uk/gov/digital/ho/hocs/queue/service/QueueAdminService.kt
+++ b/src/main/kotlin/uk/gov/digital/ho/hocs/queue/service/QueueAdminService.kt
@@ -72,10 +72,8 @@ class QueueAdminService(
             val msgCount = getMessageCount(dlqClient, dlqEndpoint)
             repeat(if (msgCount >0) num ?: msgCount else 0) {
                 dlqClient.receiveOneMessage(dlqEndpoint)?.let { msg ->
-                    log.info(msg.body)
                     messages.add(gson.fromJson(msg.body, HashMap::class.java).toString())
                 }
-
             }.also { log.info("Read messages from $name dead letter queue") }
         }
         return messages


### PR DESCRIPTION
Remove a logging line that prints out a message into a log - as this could lead to sensitive egress of information to Kibana-OpenSearch.