### PR TITLE
Standardise SQS Library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.1.0")
+	implementation("io.awspring.cloud:spring-cloud-aws-messaging:2.4.4")
 	implementation("com.google.code.gson:gson:2.10.1")
 
 	testAnnotationProcessor("org.springframework.boot:spring-boot-configuration-processor")


### PR DESCRIPTION
We currently use the spring-cloud-sqs-messaging library throughout the codebase, this change standardises the service to use this library.